### PR TITLE
doc: fix typo in reference to property "input_headers" of endpoint

### DIFF
--- a/v2.4/backend.json
+++ b/v2.4/backend.json
@@ -41,7 +41,7 @@
         "input_headers": {
             "$id": "#backend/input_headers",
             "title": "Allowed Headers In",
-            "description": "A second level of header filtering that defines the list of all headers allowed to reach this backend when different than the endpoint.\nBy default, all headers in the endpoint `header_inputs` reach the backend, unless otherwise specified here. An empty list `[]` is considered a zero-value and allows all headers to pass. Use `[\"\"]` to explicitly remove all headers. See [headers forwarding](/docs/endpoints/parameter-forwarding/#headers-forwarding)",
+            "description": "A second level of header filtering that defines the list of all headers allowed to reach this backend when different than the endpoint.\nBy default, all headers in the endpoint `input_headers` reach the backend, unless otherwise specified here. An empty list `[]` is considered a zero-value and allows all headers to pass. Use `[\"\"]` to explicitly remove all headers. See [headers forwarding](/docs/endpoints/parameter-forwarding/#headers-forwarding)",
             "type": "array",
             "uniqueItems": true,
             "default": [],


### PR DESCRIPTION
Property in `endpoint.json` is defined as "input_headers", see [this line](https://github.com/r0bb3n/krakend-schema/blob/5e8796c8db5fd1b36c529e41c0944b82f6ef65d0/v2.4/endpoint.json#L84)