### PR TITLE
Make scopes example match description.

### DIFF
--- a/v2.6/auth/client-credentials.json
+++ b/v2.6/auth/client-credentials.json
@@ -54,7 +54,7 @@
             "description": "A comma-separated list of scopes needed, e.g.: `scopeA,scopeB`\n\nSee: https://www.krakend.io/docs/authorization/client-credentials/",
             "type": "string",
             "examples": [
-                "scope1, scope2"
+                "scopeA,scopeB"
             ]
         }
     }


### PR DESCRIPTION
Description states "comma-separated list".  Make example match description.

`scopeA,scopeB` gets encoded as `scopeA+scopeB`
`scopeA, scopeB` gets encoded as `scopeA++scopeB`
Whether or not there is a space after comma is significant.