### PR TITLE
Fix duplicate `credentials_json` sub-identifiers in `gcp.json`

### DIFF
--- a/v2.3/auth/gcp.json
+++ b/v2.3/auth/gcp.json
@@ -63,7 +63,7 @@
               }]
         },
         "custom_claims": {
-            "$id": "#auth/gcp/credentials_json",
+            "$id": "#auth/gcp/custom_claims",
             "title": "Custom claims",
             "description": "Custom private claims that you can optionally add to an ID token.\n\nSee: https://www.krakend.io/docs/enterprise/authentication/gcp/",
             "type": "object"

--- a/v2.4/auth/gcp.json
+++ b/v2.4/auth/gcp.json
@@ -63,7 +63,7 @@
               }]
         },
         "custom_claims": {
-            "$id": "#auth/gcp/credentials_json",
+            "$id": "#auth/gcp/custom_claims",
             "title": "Custom claims",
             "description": "Custom private claims that you can optionally add to an ID token.\n\nSee: https://www.krakend.io/docs/enterprise/authentication/gcp/",
             "type": "object"

--- a/v2.5/auth/gcp.json
+++ b/v2.5/auth/gcp.json
@@ -63,7 +63,7 @@
               }]
         },
         "custom_claims": {
-            "$id": "#auth/gcp/credentials_json",
+            "$id": "#auth/gcp/custom_claims",
             "title": "Custom claims",
             "description": "Custom private claims that you can optionally add to an ID token.\n\nSee: https://www.krakend.io/docs/enterprise/authentication/gcp/",
             "type": "object"

--- a/v2.6/auth/gcp.json
+++ b/v2.6/auth/gcp.json
@@ -63,7 +63,7 @@
               }]
         },
         "custom_claims": {
-            "$id": "#auth/gcp/credentials_json",
+            "$id": "#auth/gcp/custom_claims",
             "title": "Custom claims",
             "description": "Custom private claims that you can optionally add to an ID token.\n\nSee: https://www.krakend.io/docs/enterprise/authentication/gcp/",
             "type": "object"


### PR DESCRIPTION
Another copy-paste issue, probably.

See: https://github.com/krakend/krakend-schema/pull/32