### PR TITLE
Fix identifer of `redis-ratelimit.json` across versions

### DIFF
--- a/v2.1/plugin/redis-ratelimit.json
+++ b/v2.1/plugin/redis-ratelimit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.krakend.io/schema/v2.1/plugin/geoip.json",
+    "$id": "https://www.krakend.io/schema/v2.1/plugin/redis-ratelimit.json",
     "title": "Redis ratelimit",
     "description": "Enterprise only. The global rate limit functionality enables a Redis database store to centralize all KrakenD node counters. Instead of having each KrakenD node count its hits, the counters are global and stored in the database.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/global-rate-limit/",
     "type": "object",

--- a/v2.2/plugin/redis-ratelimit.json
+++ b/v2.2/plugin/redis-ratelimit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.krakend.io/schema/v2.2/plugin/geoip.json",
+    "$id": "https://www.krakend.io/schema/v2.2/plugin/redis-ratelimit.json",
     "title": "Redis ratelimit",
     "description": "Enterprise only. The global rate limit functionality enables a Redis database store to centralize all KrakenD node counters. Instead of having each KrakenD node count its hits, the counters are global and stored in the database.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/global-rate-limit/",
     "type": "object",

--- a/v2.3/plugin/redis-ratelimit.json
+++ b/v2.3/plugin/redis-ratelimit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.krakend.io/schema/v2.3/plugin/geoip.json",
+    "$id": "https://www.krakend.io/schema/v2.3/plugin/redis-ratelimit.json",
     "title": "Redis ratelimit",
     "description": "Enterprise only. The global rate limit functionality enables a Redis database store to centralize all KrakenD node counters. Instead of having each KrakenD node count its hits, the counters are global and stored in the database.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/global-rate-limit/",
     "type": "object",

--- a/v2.4/plugin/redis-ratelimit.json
+++ b/v2.4/plugin/redis-ratelimit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.krakend.io/schema/v2.4/plugin/geoip.json",
+    "$id": "https://www.krakend.io/schema/v2.4/plugin/redis-ratelimit.json",
     "title": "Redis ratelimit",
     "description": "Enterprise only. The global rate limit functionality enables a Redis database store to centralize all KrakenD node counters. Instead of having each KrakenD node count its hits, the counters are global and stored in the database.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/global-rate-limit/",
     "type": "object",

--- a/v2.5/plugin/redis-ratelimit.json
+++ b/v2.5/plugin/redis-ratelimit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.krakend.io/schema/v2.5/plugin/geoip.json",
+    "$id": "https://www.krakend.io/schema/v2.5/plugin/redis-ratelimit.json",
     "title": "Redis ratelimit",
     "description": "Enterprise only. The global rate limit functionality enables a Redis database store to centralize all KrakenD node counters. Instead of having each KrakenD node count its hits, the counters are global and stored in the database.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/global-rate-limit/",
     "type": "object",

--- a/v2.6/plugin/redis-ratelimit.json
+++ b/v2.6/plugin/redis-ratelimit.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.krakend.io/schema/v2.6/plugin/geoip.json",
+    "$id": "https://www.krakend.io/schema/v2.6/plugin/redis-ratelimit.json",
     "title": "Redis ratelimit",
     "description": "Enterprise only. The global rate limit functionality enables a Redis database store to centralize all KrakenD node counters. Instead of having each KrakenD node count its hits, the counters are global and stored in the database.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/global-rate-limit/",
     "type": "object",


### PR DESCRIPTION
Probably another copy-paste issue.