### PR TITLE
Set proper identifiers for `bot-detector.json` across versions

### DIFF
--- a/v2.1/security/bot-detector.json
+++ b/v2.1/security/bot-detector.json
@@ -1,5 +1,5 @@
 {
-    "$id": "#security/bot-detector",
+    "$id": "https://www.krakend.io/schema/v2.1/security/bot-detector.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Bot detector",
     "description": "The bot detector module checks incoming connections to the gateway to determine if a bot made them, helping you detect and reject bots carrying out scraping, content theft, and form spam.\n\nSee: https://www.krakend.io/docs/throttling/botdetector/",

--- a/v2.2/security/bot-detector.json
+++ b/v2.2/security/bot-detector.json
@@ -1,5 +1,5 @@
 {
-    "$id": "#security/bot-detector",
+    "$id": "https://www.krakend.io/schema/v2.2/security/bot-detector.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Bot detector",
     "description": "The bot detector module checks incoming connections to the gateway to determine if a bot made them, helping you detect and reject bots carrying out scraping, content theft, and form spam.\n\nSee: https://www.krakend.io/docs/throttling/botdetector/",

--- a/v2.3/security/bot-detector.json
+++ b/v2.3/security/bot-detector.json
@@ -1,5 +1,5 @@
 {
-    "$id": "#security/bot-detector",
+    "$id": "https://www.krakend.io/schema/v2.3/security/bot-detector.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Bot detector",
     "description": "The bot detector module checks incoming connections to the gateway to determine if a bot made them, helping you detect and reject bots carrying out scraping, content theft, and form spam.\n\nSee: https://www.krakend.io/docs/throttling/botdetector/",

--- a/v2.4/security/bot-detector.json
+++ b/v2.4/security/bot-detector.json
@@ -1,5 +1,5 @@
 {
-    "$id": "#security/bot-detector",
+    "$id": "https://www.krakend.io/schema/v2.4/security/bot-detector.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Bot detector",
     "description": "The bot detector module checks incoming connections to the gateway to determine if a bot made them, helping you detect and reject bots carrying out scraping, content theft, and form spam.\n\nSee: https://www.krakend.io/docs/throttling/botdetector/",

--- a/v2.5/security/bot-detector.json
+++ b/v2.5/security/bot-detector.json
@@ -1,5 +1,5 @@
 {
-    "$id": "#security/bot-detector",
+    "$id": "https://www.krakend.io/schema/v2.5/security/bot-detector.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Bot detector",
     "description": "The bot detector module checks incoming connections to the gateway to determine if a bot made them, helping you detect and reject bots carrying out scraping, content theft, and form spam.\n\nSee: https://www.krakend.io/docs/throttling/botdetector/",

--- a/v2.6/security/bot-detector.json
+++ b/v2.6/security/bot-detector.json
@@ -1,5 +1,5 @@
 {
-    "$id": "#security/bot-detector",
+    "$id": "https://www.krakend.io/schema/v2.6/security/bot-detector.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Bot detector",
     "description": "The bot detector module checks incoming connections to the gateway to determine if a bot made them, helping you detect and reject bots carrying out scraping, content theft, and form spam.\n\nSee: https://www.krakend.io/docs/throttling/botdetector/",


### PR DESCRIPTION
Otherwise references to it from other schemas are not resolving.