### PR TITLE
Add an example JSON Schema unit test for v2.6 `JMESPath`

### DIFF
--- a/.github/workflows/validate-json-schema.yml
+++ b/.github/workflows/validate-json-schema.yml
@@ -1,21 +1,16 @@
 on: [push]
-name: Validate JSON schema
+name: Validate JSON Schema
 jobs:
-  validate_configurations:
-    name: Validate all json files using their own $schema properties
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: intelligence-ai/jsonschema@v0.6.0
-      - run: jsonschema fmt --ignore test --check --verbose
-      - run: jsonschema lint --ignore test --verbose
-      - run: jsonschema test ./test/v2.6 --resolve v2.6
-
-      - name: Validate components
-        uses: cardinalby/schema-validator-action@v1
-        with:
-          file: '**/*.json'
-      - name: Validate root documents
-        uses: cardinalby/schema-validator-action@v1
-        with:
-          file: '*.json'
+      - uses: intelligence-ai/jsonschema@v1.0.0
+      - name: Ensure JSON Schemas are formatted
+        run: jsonschema fmt --ignore test --check --verbose
+      - name: Lint JSON Schemas
+        run: jsonschema lint --ignore test --verbose
+      - name: Ensure JSON Schemas are valid with respect to their metaschemas
+        run: jsonschema metaschema --ignore test --verbose
+      - name: Run JSON Schema unit tests
+        run: jsonschema test ./test/v2.6 --resolve v2.6

--- a/.github/workflows/validate-json-schema.yml
+++ b/.github/workflows/validate-json-schema.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: intelligence-ai/jsonschema@v0.5.0
-      - run: jsonschema fmt v2.1 v2.2 v2.3 v2.4 v2.5 v2.6 --check --verbose
-      - run: jsonschema lint v2.1 v2.2 v2.3 v2.4 v2.5 v2.6 --verbose
+      - uses: intelligence-ai/jsonschema@v0.6.0
+      - run: jsonschema fmt --ignore test --check --verbose
+      - run: jsonschema lint --ignore test --verbose
       - run: jsonschema test ./test/v2.6 --resolve v2.6
 
       - name: Validate components

--- a/.github/workflows/validate-json-schema.yml
+++ b/.github/workflows/validate-json-schema.yml
@@ -6,9 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: intelligence-ai/jsonschema@v0.2.0
-      - run: jsonschema fmt --check --verbose
-      - run: jsonschema lint --verbose
+      - uses: intelligence-ai/jsonschema@v0.5.0
+      - run: jsonschema fmt v2.1 v2.2 v2.3 v2.4 v2.5 v2.6 --check --verbose
+      - run: jsonschema lint v2.1 v2.2 v2.3 v2.4 v2.5 v2.6 --verbose
+      - run: jsonschema test ./test/v2.6 --resolve v2.6
+
       - name: Validate components
         uses: cardinalby/schema-validator-action@v1
         with:

--- a/test/v2.6/modifier/jmespath.json
+++ b/test/v2.6/modifier/jmespath.json
@@ -1,0 +1,18 @@
+{
+  "description": "JMESPath",
+  "schema": "https://www.krakend.io/schema/v2.6/modifier/jmespath.json",
+  "tests": [
+    {
+      "description": "the empty object is invalid",
+      "valid": false,
+      "data": {}
+    },
+    {
+      "description": "example expression",
+      "valid": true,
+      "data": {
+        "expr": "students[?age > `18` ].name"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I added the suite at `test/v2.6/modifier/jmespath.json`, which adds two sample tests (one valid and one invalid).

Here is how the GitHub Action would run it and the respective results:

```sh
$ jsonschema test ./test/v2.6 --resolve v2.6
./test/v2.6/modifier/jmespath.json
    JMESPath - the empty object is invalid
        PASS
    JMESPath - example expression
        PASS
```