### PR TITLE
Avoid a top-level `$ref` in `krakend.json`

### DIFF
--- a/krakend.json
+++ b/krakend.json
@@ -2,5 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://www.krakend.io/schema/krakend.json",
   "title": "Schema validation for the latest version of KrakenD. Consider sticking to the specific version you are using.",
-  "$ref": "v2.6/krakend.json"
+  "allOf": [
+    {
+      "$ref": "v2.6/krakend.json"
+    }
+  ]
 }


### PR DESCRIPTION
In JSON Schema Draft 7 and older, the `$ref` keyword takes precedence over any other keyword, essentially making the rest ignored. From https://json-schema.org/draft-07/draft-handrews-json-schema-01#rfc.section.8.3:

> An object schema with a "$ref" property MUST be interpreted as a
> "$ref" reference [...] All other properties in a "$ref" object MUST be
> ignored.

While some JSON Schema implementations are permissive and allow this anyway, this change makes the top-level schema fully compliant.