### PR TITLE
Upgrade to JSON Schema CLI v1.1.2

### DIFF
--- a/.github/workflows/validate-json-schema.yml
+++ b/.github/workflows/validate-json-schema.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: intelligence-ai/jsonschema@v1.1.1
+      - uses: intelligence-ai/jsonschema@v1.1.2
       - name: Ensure JSON Schemas are formatted
         run: jsonschema fmt --ignore test --check --verbose
       - name: Lint JSON Schemas


### PR DESCRIPTION
It heavily speeds up schema compilation, which was affecting the `test` command when compiling the top-level huge schema.

See: https://github.com/krakend/krakend-schema/pull/43