### PR TITLE
add missing properties for backend otel configuration

### DIFF
--- a/test/v2.7/all.json
+++ b/test/v2.7/all.json
@@ -295,16 +295,31 @@
                                         }
                                     },
                                     "telemetry/opentelemetry": {
-                                        "proxy": {
-                                            "disable_metrics": true,
-                                            "disable_traces": true
-                                        },
                                         "backend": {
                                             "metrics": {
-                                                "disable_stage": true
+                                                "detailed_connection": true,
+                                                "disable_stage": true,
+                                                "read_payload": true,
+                                                "round_trip": true,
+                                                "static_attributes": [
+                                                    {
+                                                        "key": "met_bckdef_key",
+                                                        "value": "met_bckdef_val"
+                                                    }
+                                                ]
                                             },
                                             "traces": {
-                                                "disable_stage": true
+                                                "detailed_connection": true,
+                                                "disable_stage": true,
+                                                "read_payload": true,
+                                                "round_trip": true,
+                                                "static_attributes": [
+                                                    {
+                                                        "key": "met_bckdef_key",
+                                                        "value": "met_bckdef_val"
+                                                    }
+                                                ],
+                                                "report_headers": true
                                             }
                                         }
                                     }
@@ -320,7 +335,19 @@
                             "telemetry/opentelemetry": {
                                 "proxy": {
                                     "disable_metrics": false,
-                                    "disable_traces": false
+                                    "disable_traces": false,
+                                    "metrics_static_attributes": [
+                                        {
+                                            "key": "met_endpointdef_key",
+                                            "value": "met_endpointdef_val"
+                                        }
+                                    ],
+                                    "traces_static_attributes": [
+                                        {
+                                            "key": "met_endpointdef_key",
+                                            "value": "met_dendpointdef_val"
+                                        }
+                                    ]
                                 },
                                 "exporters_override": {
                                     "metric_reporting_period": 10,

--- a/v2.7/krakend.json
+++ b/v2.7/krakend.json
@@ -6964,11 +6964,65 @@
             "metrics": {
               "type": "object",
               "properties": {
+                "detailed_connection": {
+                  "title": "Detailed HTTP connection metrics",
+                  "description": "Whether you want to enable detailed metrics for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
                 "disable_stage": {
                   "title": "Disable this stage",
                   "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
                   "default": false,
                   "type": "boolean"
+                },
+                "read_payload": {
+                  "title": "Detailed payload read",
+                  "description": "Whether you want to enable metrics for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "round_trip": {
+                  "title": "Detailed Round Trip",
+                  "description": "Whether you want to enable metrics for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "static_attributes": {
+                  "title": "static attributes",
+                  "description": "a list of tags or labels you want to associate with these metrics.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "examples": [
+                    [
+                      {
+                        "key": "my_metric_attr",
+                        "value": "my_metric_val"
+                      }
+                    ]
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "title": "key",
+                        "description": "the key, tag, or label name you want to use.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "value",
+                        "description": "the static value you want to assign to this key.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      }
+                    },
+                    "additionalproperties": false,
+                    "patternproperties": {
+                      "^[@$_#]": {}
+                    }
+                  }
                 }
               },
               "patternProperties": {
@@ -6979,40 +7033,77 @@
             "traces": {
               "type": "object",
               "properties": {
+                "detailed_connection": {
+                  "title": "Detailed HTTP connection",
+                  "description": "Whether you want to add detailed trace attributes for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
                 "disable_stage": {
                   "title": "Disable this stage",
                   "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
                   "default": false,
                   "type": "boolean"
+                },
+                "read_payload": {
+                  "title": "Detailed payload read",
+                  "description": "Whether you want to add trace attributes for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "report_headers": {
+                  "title": "Report headers",
+                  "description": "Whether you want to report the final headers that reached the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "round_trip": {
+                  "title": "Detailed Round Trip",
+                  "description": "Whether you want to add trace attributes for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "static_attributes": {
+                  "title": "static attributes",
+                  "description": "a list of tags or labels you want to associate with these metrics.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "examples": [
+                    [
+                      {
+                        "key": "my_metric_attr",
+                        "value": "my_metric_val"
+                      }
+                    ]
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "title": "key",
+                        "description": "the key, tag, or label name you want to use.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "value",
+                        "description": "the static value you want to assign to this key.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      }
+                    },
+                    "additionalproperties": false,
+                    "patternproperties": {
+                      "^[@$_#]": {}
+                    }
+                  }
                 }
               },
               "patternProperties": {
                 "^[@$_#]": {}
               },
               "additionalProperties": false
-            }
-          },
-          "patternProperties": {
-            "^[@$_#]": {}
-          },
-          "additionalProperties": false
-        },
-        "proxy": {
-          "title": "Report proxy activity",
-          "description": "Reports the activity at the beginning of the proxy layer, including spawning the required requests to multiple backends, merging, endpoint transformation and any other internals of the proxy between the request processing and the backend communication\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-          "type": "object",
-          "properties": {
-            "disable_metrics": {
-              "title": "Disable metrics",
-              "description": "Whether you want to disable all metrics in this endpoint or not.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-              "default": false,
-              "type": "boolean"
-            },
-            "disable_traces": {
-              "title": "Disable traces",
-              "description": "Whether you want to disable all traces in this endpoint or not.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-              "default": false,
-              "type": "boolean"
             }
           },
           "patternProperties": {
@@ -7032,6 +7123,161 @@
       "description": "Enterprise only. Overrides metrics and traces declared by the OpenTelemetry service.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
       "type": "object",
       "properties": {
+        "backend": {
+          "title": "Report backend activity",
+          "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+          "type": "object",
+          "properties": {
+            "metrics": {
+              "type": "object",
+              "properties": {
+                "detailed_connection": {
+                  "title": "Detailed HTTP connection metrics",
+                  "description": "Whether you want to enable detailed metrics for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "disable_stage": {
+                  "title": "Disable this stage",
+                  "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "read_payload": {
+                  "title": "Detailed payload read",
+                  "description": "Whether you want to enable metrics for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "round_trip": {
+                  "title": "Detailed Round Trip",
+                  "description": "Whether you want to enable metrics for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "static_attributes": {
+                  "title": "Static attributes",
+                  "description": "A list of tags or labels you want to associate with these metrics.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "examples": [
+                    [
+                      {
+                        "key": "my_metric_attr",
+                        "value": "my_metric_val"
+                      }
+                    ]
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "title": "Key",
+                        "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "Value",
+                        "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      }
+                    },
+                    "patternProperties": {
+                      "^[@$_#]": {}
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "patternProperties": {
+                "^[@$_#]": {}
+              },
+              "additionalProperties": false
+            },
+            "traces": {
+              "type": "object",
+              "properties": {
+                "detailed_connection": {
+                  "title": "Detailed HTTP connection",
+                  "description": "Whether you want to add detailed trace attributes for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "disable_stage": {
+                  "title": "Disable this stage",
+                  "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "read_payload": {
+                  "title": "Detailed payload read",
+                  "description": "Whether you want to add trace attributes for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "report_headers": {
+                  "title": "Report headers",
+                  "description": "Whether you want to report the final headers that reached the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "round_trip": {
+                  "title": "Detailed Round Trip",
+                  "description": "Whether you want to add trace attributes for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "static_attributes": {
+                  "title": "Static attributes",
+                  "description": "A list of tags or labels you want to associate to these traces.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "examples": [
+                    [
+                      {
+                        "key": "my_trace_attr",
+                        "value": "my_trace_val"
+                      }
+                    ]
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "title": "Key",
+                        "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "Value",
+                        "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      }
+                    },
+                    "patternProperties": {
+                      "^[@$_#]": {}
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "patternProperties": {
+                "^[@$_#]": {}
+              },
+              "additionalProperties": false
+            }
+          },
+          "patternProperties": {
+            "^[@$_#]": {}
+          },
+          "additionalProperties": false
+        },
         "exporters_override": {
           "title": "Exporters override",
           "description": "Override exporter configuration for this endpoint",
@@ -7096,6 +7342,52 @@
               "description": "Whether you want to disable all traces in this endpoint or not.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
               "default": false,
               "type": "boolean"
+            },
+            "metrics_static_attributes": {
+              "title": "Static attributes",
+              "description": "Static attributes you want to pass for metrics.",
+              "type": "array",
+              "items": {
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "description": "The key of the static attribute you want to send",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The value of the static attribute you want to send",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "report_headers": {
+              "title": "Report headers",
+              "description": "Whether you want to report all headers that passed from the request to the proxy layer (`input_headers` policy in the endpoint plus KrakenD's headers).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "traces_static_attributes": {
+              "title": "Static attributes",
+              "description": "Static attributes you want to pass for traces.",
+              "type": "array",
+              "items": {
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "description": "The key of the static attribute you want to send",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The value of the static attribute you want to send",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
             }
           },
           "patternProperties": {

--- a/v2.7/telemetry/opentelemetry-backend.json
+++ b/v2.7/telemetry/opentelemetry-backend.json
@@ -5,118 +5,6 @@
   "description": "Enterprise only. Overrides metrics and traces declared by the OpenTelemetry service.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
   "type": "object",
   "properties": {
-    "layers": {
-      "title": "Layers",
-      "description": "A request and response flow passes through three different layers. This sections allows to add backend layer properties to a single backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-      "type": "object",
-      "properties": {
-        "backend": {
-          "title": "Report backend activity",
-          "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-          "type": "object",
-          "properties": {
-            "metrics": {
-              "type": "object",
-              "properties": {
-                "static_attributes": {
-                  "title": "Static attributes",
-                  "description": "A list of tags or labels you want to associate with these metrics.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                  "examples": [
-                    [
-                      {
-                        "key": "my_metric_attr",
-                        "value": "my_metric_val"
-                      }
-                    ]
-                  ],
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "key",
-                      "value"
-                    ],
-                    "properties": {
-                      "key": {
-                        "title": "Key",
-                        "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                        "type": "string"
-                      },
-                      "value": {
-                        "title": "Value",
-                        "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                        "type": "string"
-                      }
-                    },
-                    "patternProperties": {
-                      "^[@$_#]": {}
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "patternProperties": {
-                "^[@$_#]": {}
-              },
-              "additionalProperties": false
-            },
-            "traces": {
-              "type": "object",
-              "properties": {
-                "static_attributes": {
-                  "title": "Static attributes",
-                  "description": "A list of tags or labels you want to associate to these traces.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                  "examples": [
-                    [
-                      {
-                        "key": "my_trace_attr",
-                        "value": "my_trace_val"
-                      }
-                    ]
-                  ],
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "key",
-                      "value"
-                    ],
-                    "properties": {
-                      "key": {
-                        "title": "Key",
-                        "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                        "type": "string"
-                      },
-                      "value": {
-                        "title": "Value",
-                        "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                        "type": "string"
-                      }
-                    },
-                    "patternProperties": {
-                      "^[@$_#]": {}
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "patternProperties": {
-                "^[@$_#]": {}
-              },
-              "additionalProperties": false
-            }
-          },
-          "patternProperties": {
-            "^[@$_#]": {}
-          },
-          "additionalProperties": false
-        }
-      },
-      "patternProperties": {
-        "^[@$_#]": {}
-      },
-      "additionalProperties": false
-    },
     "backend": {
       "title": "Report backend activity",
       "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
@@ -130,6 +18,42 @@
               "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
+            },
+            "static_attributes": {
+              "title": "static attributes",
+              "description": "a list of tags or labels you want to associate with these metrics.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "examples": [
+                [
+                  {
+                    "key": "my_metric_attr",
+                    "value": "my_metric_val"
+                  }
+                ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "title": "key",
+                    "description": "the key, tag, or label name you want to use.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "value",
+                    "description": "the static value you want to assign to this key.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  }
+                },
+                "patternproperties": {
+                  "^[@$_#]": {}
+                },
+                "additionalproperties": false
+              }
             }
           },
           "patternProperties": {
@@ -145,35 +69,48 @@
               "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
+            },
+            "static_attributes": {
+              "title": "static attributes",
+              "description": "a list of tags or labels you want to associate with these metrics.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "examples": [
+                [
+                  {
+                    "key": "my_metric_attr",
+                    "value": "my_metric_val"
+                  }
+                ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "title": "key",
+                    "description": "the key, tag, or label name you want to use.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "value",
+                    "description": "the static value you want to assign to this key.\n\nsee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  }
+                },
+                "patternproperties": {
+                  "^[@$_#]": {}
+                },
+                "additionalproperties": false
+              }
             }
           },
           "patternProperties": {
             "^[@$_#]": {}
           },
           "additionalProperties": false
-        }
-      },
-      "patternProperties": {
-        "^[@$_#]": {}
-      },
-      "additionalProperties": false
-    },
-    "proxy": {
-      "title": "Report proxy activity",
-      "description": "Reports the activity at the beginning of the proxy layer, including spawning the required requests to multiple backends, merging, endpoint transformation and any other internals of the proxy between the request processing and the backend communication\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-      "type": "object",
-      "properties": {
-        "disable_metrics": {
-          "title": "Disable metrics",
-          "description": "Whether you want to disable all metrics in this endpoint or not.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-          "default": false,
-          "type": "boolean"
-        },
-        "disable_traces": {
-          "title": "Disable traces",
-          "description": "Whether you want to disable all traces in this endpoint or not.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-          "default": false,
-          "type": "boolean"
         }
       },
       "patternProperties": {

--- a/v2.7/telemetry/opentelemetry-backend.json
+++ b/v2.7/telemetry/opentelemetry-backend.json
@@ -5,6 +5,118 @@
   "description": "Enterprise only. Overrides metrics and traces declared by the OpenTelemetry service.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
   "type": "object",
   "properties": {
+    "layers": {
+      "title": "Layers",
+      "description": "A request and response flow passes through three different layers. This sections allows to add backend layer properties to a single backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+      "type": "object",
+      "properties": {
+        "backend": {
+          "title": "Report backend activity",
+          "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+          "type": "object",
+          "properties": {
+            "metrics": {
+              "type": "object",
+              "properties": {
+                "static_attributes": {
+                  "title": "Static attributes",
+                  "description": "A list of tags or labels you want to associate with these metrics.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "examples": [
+                    [
+                      {
+                        "key": "my_metric_attr",
+                        "value": "my_metric_val"
+                      }
+                    ]
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "title": "Key",
+                        "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "Value",
+                        "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      }
+                    },
+                    "patternProperties": {
+                      "^[@$_#]": {}
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "patternProperties": {
+                "^[@$_#]": {}
+              },
+              "additionalProperties": false
+            },
+            "traces": {
+              "type": "object",
+              "properties": {
+                "static_attributes": {
+                  "title": "Static attributes",
+                  "description": "A list of tags or labels you want to associate to these traces.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                  "examples": [
+                    [
+                      {
+                        "key": "my_trace_attr",
+                        "value": "my_trace_val"
+                      }
+                    ]
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "properties": {
+                      "key": {
+                        "title": "Key",
+                        "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      },
+                      "value": {
+                        "title": "Value",
+                        "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                        "type": "string"
+                      }
+                    },
+                    "patternProperties": {
+                      "^[@$_#]": {}
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "patternProperties": {
+                "^[@$_#]": {}
+              },
+              "additionalProperties": false
+            }
+          },
+          "patternProperties": {
+            "^[@$_#]": {}
+          },
+          "additionalProperties": false
+        }
+      },
+      "patternProperties": {
+        "^[@$_#]": {}
+      },
+      "additionalProperties": false
+    },
     "backend": {
       "title": "Report backend activity",
       "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
@@ -18,60 +130,6 @@
               "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
-            },
-            "round_trip": {
-              "title": "Report backend round trip metrics",
-              "description": "Provide metrics about the round trip time for backend requests. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "read_payload": {
-              "title": "Report backend read payload time",
-              "description": "Provide metrics about how long it takes to read the response payload from the backend. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "detailed_connection": {
-              "title": "Report backend connection details timing",
-              "description": "Provide metrics about how long it takes to query the DNS and initiating a connection to the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "static_attributes": {
-              "title": "Static attributes",
-              "description": "A list of tags or labels you want to associate with these metrics.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "examples": [
-                [
-                  {
-                    "key": "my_metric_attr",
-                    "value": "my_metric_val"
-                  }
-                ]
-              ],
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "key",
-                  "value"
-                ],
-                "properties": {
-                  "key": {
-                    "title": "Key",
-                    "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                    "type": "string"
-                  },
-                  "value": {
-                    "title": "Value",
-                    "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                    "type": "string"
-                  }
-                },
-                "patternProperties": {
-                  "^[@$_#]": {}
-                },
-                "additionalProperties": false
-              }
             }
           },
           "patternProperties": {
@@ -87,66 +145,6 @@
               "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
-            },
-            "round_trip": {
-              "title": "Report backend round trip times",
-              "description": "Add attribute with the round trip time for the bakcend requests.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "read_payload": {
-              "title": "Report backend read payload time",
-              "description": "Add span with how long it takes to read the response payload from the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "detailed_connection": {
-              "title": "Report backend connection details timing",
-              "description": "Add attribute with the time it takes to query the DNS and initiating a connection to the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "report_headers": {
-              "title": "Report headers",
-              "description": "Add attribute with the headers that are sent to the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "default": false,
-              "type": "boolean"
-            },
-            "static_attributes": {
-              "title": "Static attributes",
-              "description": "A list of tags or labels you want to associate with the trace.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-              "examples": [
-                [
-                  {
-                    "key": "my_trace_attr",
-                    "value": "my_trace_val"
-                  }
-                ]
-              ],
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "key",
-                  "value"
-                ],
-                "properties": {
-                  "key": {
-                    "title": "Key",
-                    "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                    "type": "string"
-                  },
-                  "value": {
-                    "title": "Value",
-                    "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
-                    "type": "string"
-                  }
-                },
-                "patternProperties": {
-                  "^[@$_#]": {}
-                },
-                "additionalProperties": false
-              }
             }
           },
           "patternProperties": {

--- a/v2.7/telemetry/opentelemetry-backend.json
+++ b/v2.7/telemetry/opentelemetry-backend.json
@@ -13,9 +13,27 @@
         "metrics": {
           "type": "object",
           "properties": {
+            "detailed_connection": {
+              "title": "Detailed HTTP connection metrics",
+              "description": "Whether you want to enable detailed metrics for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
             "disable_stage": {
               "title": "Disable this stage",
               "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "read_payload": {
+              "title": "Detailed payload read",
+              "description": "Whether you want to enable metrics for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "round_trip": {
+              "title": "Detailed Round Trip",
+              "description": "Whether you want to enable metrics for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
             },
@@ -64,9 +82,33 @@
         "traces": {
           "type": "object",
           "properties": {
+            "detailed_connection": {
+              "title": "Detailed HTTP connection",
+              "description": "Whether you want to add detailed trace attributes for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
             "disable_stage": {
               "title": "Disable this stage",
               "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "read_payload": {
+              "title": "Detailed payload read",
+              "description": "Whether you want to add trace attributes for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "report_headers": {
+              "title": "Report headers",
+              "description": "Whether you want to report the final headers that reached the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "round_trip": {
+              "title": "Detailed Round Trip",
+              "description": "Whether you want to add trace attributes for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
             },

--- a/v2.7/telemetry/opentelemetry-backend.json
+++ b/v2.7/telemetry/opentelemetry-backend.json
@@ -18,6 +18,60 @@
               "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
+            },
+            "round_trip": {
+              "title": "Report backend round trip metrics",
+              "description": "Provide metrics about the round trip time for backend requests. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "read_payload": {
+              "title": "Report backend read payload time",
+              "description": "Provide metrics about how long it takes to read the response payload from the backend. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "detailed_connection": {
+              "title": "Report backend connection details timing",
+              "description": "Provide metrics about how long it takes to query the DNS and initiating a connection to the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "static_attributes": {
+              "title": "Static attributes",
+              "description": "A list of tags or labels you want to associate with these metrics.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "examples": [
+                [
+                  {
+                    "key": "my_metric_attr",
+                    "value": "my_metric_val"
+                  }
+                ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  }
+                },
+                "patternProperties": {
+                  "^[@$_#]": {}
+                },
+                "additionalProperties": false
+              }
             }
           },
           "patternProperties": {
@@ -33,6 +87,66 @@
               "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
               "default": false,
               "type": "boolean"
+            },
+            "round_trip": {
+              "title": "Report backend round trip times",
+              "description": "Add attribute with the round trip time for the bakcend requests.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "read_payload": {
+              "title": "Report backend read payload time",
+              "description": "Add span with how long it takes to read the response payload from the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "detailed_connection": {
+              "title": "Report backend connection details timing",
+              "description": "Add attribute with the time it takes to query the DNS and initiating a connection to the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "report_headers": {
+              "title": "Report headers",
+              "description": "Add attribute with the headers that are sent to the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "static_attributes": {
+              "title": "Static attributes",
+              "description": "A list of tags or labels you want to associate with the trace.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "examples": [
+                [
+                  {
+                    "key": "my_trace_attr",
+                    "value": "my_trace_val"
+                  }
+                ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  }
+                },
+                "patternProperties": {
+                  "^[@$_#]": {}
+                },
+                "additionalProperties": false
+              }
             }
           },
           "patternProperties": {

--- a/v2.7/telemetry/opentelemetry-backend.json
+++ b/v2.7/telemetry/opentelemetry-backend.json
@@ -67,10 +67,10 @@
                     "type": "string"
                   }
                 },
+                "additionalproperties": false,
                 "patternproperties": {
                   "^[@$_#]": {}
-                },
-                "additionalproperties": false
+                }
               }
             }
           },
@@ -142,10 +142,10 @@
                     "type": "string"
                   }
                 },
+                "additionalproperties": false,
                 "patternproperties": {
                   "^[@$_#]": {}
-                },
-                "additionalproperties": false
+                }
               }
             }
           },

--- a/v2.7/telemetry/opentelemetry-endpoint.json
+++ b/v2.7/telemetry/opentelemetry-endpoint.json
@@ -53,6 +53,161 @@
       },
       "additionalProperties": false
     },
+    "backend": {
+      "title": "Report backend activity",
+      "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "detailed_connection": {
+              "title": "Detailed HTTP connection metrics",
+              "description": "Whether you want to enable detailed metrics for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "disable_stage": {
+              "title": "Disable this stage",
+              "description": "Whether to turn off the metrics or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "read_payload": {
+              "title": "Detailed payload read",
+              "description": "Whether you want to enable metrics for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "round_trip": {
+              "title": "Detailed Round Trip",
+              "description": "Whether you want to enable metrics for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "static_attributes": {
+              "title": "Static attributes",
+              "description": "A list of tags or labels you want to associate with these metrics.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "examples": [
+                [
+                  {
+                    "key": "my_metric_attr",
+                    "value": "my_metric_val"
+                  }
+                ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  }
+                },
+                "patternProperties": {
+                  "^[@$_#]": {}
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "patternProperties": {
+            "^[@$_#]": {}
+          },
+          "additionalProperties": false
+        },
+        "traces": {
+          "type": "object",
+          "properties": {
+            "detailed_connection": {
+              "title": "Detailed HTTP connection",
+              "description": "Whether you want to add detailed trace attributes for the HTTP connection phase or not. Includes times to connect, DNS querying, and the TLS handshake.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "disable_stage": {
+              "title": "Disable this stage",
+              "description": "Whether to turn off the traces or not. Setting this to `true` means stop reporting any data.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "read_payload": {
+              "title": "Detailed payload read",
+              "description": "Whether you want to add trace attributes for the response reading payload or not (HTTP connection not taken into account).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "report_headers": {
+              "title": "Report headers",
+              "description": "Whether you want to report the final headers that reached the backend.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "round_trip": {
+              "title": "Detailed Round Trip",
+              "description": "Whether you want to add trace attributes for the actual HTTP request for the backend or not (manipulation not taken into account). This is the time your backend needs to produce a result.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "default": false,
+              "type": "boolean"
+            },
+            "static_attributes": {
+              "title": "Static attributes",
+              "description": "A list of tags or labels you want to associate to these traces.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+              "examples": [
+                [
+                  {
+                    "key": "my_trace_attr",
+                    "value": "my_trace_val"
+                  }
+                ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "description": "The key, tag, or label name you want to use.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The static value you want to assign to this key.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+                    "type": "string"
+                  }
+                },
+                "patternProperties": {
+                  "^[@$_#]": {}
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "patternProperties": {
+            "^[@$_#]": {}
+          },
+          "additionalProperties": false
+        }
+      },
+      "patternProperties": {
+        "^[@$_#]": {}
+      },
+      "additionalProperties": false
+    },
     "proxy": {
       "title": "Report proxy activity",
       "description": "Reports the activity at the beginning of the proxy layer, including spawning the required requests to multiple backends, merging, endpoint transformation and any other internals of the proxy between the request processing and the backend communication\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
@@ -69,6 +224,52 @@
           "description": "Whether you want to disable all traces in this endpoint or not.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
           "default": false,
           "type": "boolean"
+        },
+        "metrics_static_attributes": {
+          "title": "Static attributes",
+          "description": "Static attributes you want to pass for metrics.",
+          "type": "array",
+          "items": {
+            "properties": {
+              "key": {
+                "title": "Key",
+                "description": "The key of the static attribute you want to send",
+                "type": "string"
+              },
+              "value": {
+                "title": "Value",
+                "description": "The value of the static attribute you want to send",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "report_headers": {
+          "title": "Report headers",
+          "description": "Whether you want to report all headers that passed from the request to the proxy layer (`input_headers` policy in the endpoint plus KrakenD's headers).\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
+          "default": false,
+          "type": "boolean"
+        },
+        "traces_static_attributes": {
+          "title": "Static attributes",
+          "description": "Static attributes you want to pass for traces.",
+          "type": "array",
+          "items": {
+            "properties": {
+              "key": {
+                "title": "Key",
+                "description": "The key of the static attribute you want to send",
+                "type": "string"
+              },
+              "value": {
+                "title": "Value",
+                "description": "The value of the static attribute you want to send",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "patternProperties": {

--- a/v2.7/telemetry/opentelemetry-endpoint.json
+++ b/v2.7/telemetry/opentelemetry-endpoint.json
@@ -5,54 +5,6 @@
   "description": "Enterprise only. Overrides metrics and traces declared by the OpenTelemetry service.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
   "type": "object",
   "properties": {
-    "exporters_override": {
-      "title": "Exporters override",
-      "description": "Override exporter configuration for this endpoint",
-      "type": "object",
-      "properties": {
-        "metric_exporters": {
-          "title": "Metrics exporters",
-          "description": "Overrides the metrics exporters used in this endpoint",
-          "examples": [
-            [
-              "local_prometheus"
-            ]
-          ],
-          "type": "array"
-        },
-        "metric_reporting_period": {
-          "title": "Reporting period",
-          "description": "Override how often you want to report and flush the metrics in seconds.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-          "type": "integer"
-        },
-        "trace_exporters": {
-          "title": "Trace exporters",
-          "description": "Overrides the trace exporters used in this endpoint",
-          "examples": [
-            [
-              "debug_jaeger",
-              "newrelic",
-              "local_tempo"
-            ]
-          ],
-          "type": "array"
-        },
-        "trace_sample_rate": {
-          "title": "Trace sample rate",
-          "description": "Overrides the sample rate for traces defines the percentage of reported traces. This option is key to reduce the amount of data generated (and resource usage), while you still can debug and troubleshoot issues. For instance, a number of `0.25` will report a 25% of the traces seen in the system.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-          "examples": [
-            0.25
-          ],
-          "type": "number",
-          "maximum": 1,
-          "minimum": 0
-        }
-      },
-      "patternProperties": {
-        "^[@$_#]": {}
-      },
-      "additionalProperties": false
-    },
     "backend": {
       "title": "Report backend activity",
       "description": "Reports the activity between KrakenD and each of your backend services. This is the more granular layer.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry/",
@@ -201,6 +153,54 @@
             "^[@$_#]": {}
           },
           "additionalProperties": false
+        }
+      },
+      "patternProperties": {
+        "^[@$_#]": {}
+      },
+      "additionalProperties": false
+    },
+    "exporters_override": {
+      "title": "Exporters override",
+      "description": "Override exporter configuration for this endpoint",
+      "type": "object",
+      "properties": {
+        "metric_exporters": {
+          "title": "Metrics exporters",
+          "description": "Overrides the metrics exporters used in this endpoint",
+          "examples": [
+            [
+              "local_prometheus"
+            ]
+          ],
+          "type": "array"
+        },
+        "metric_reporting_period": {
+          "title": "Reporting period",
+          "description": "Override how often you want to report and flush the metrics in seconds.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
+          "type": "integer"
+        },
+        "trace_exporters": {
+          "title": "Trace exporters",
+          "description": "Overrides the trace exporters used in this endpoint",
+          "examples": [
+            [
+              "debug_jaeger",
+              "newrelic",
+              "local_tempo"
+            ]
+          ],
+          "type": "array"
+        },
+        "trace_sample_rate": {
+          "title": "Trace sample rate",
+          "description": "Overrides the sample rate for traces defines the percentage of reported traces. This option is key to reduce the amount of data generated (and resource usage), while you still can debug and troubleshoot issues. For instance, a number of `0.25` will report a 25% of the traces seen in the system.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
+          "examples": [
+            0.25
+          ],
+          "type": "number",
+          "maximum": 1,
+          "minimum": 0
         }
       },
       "patternProperties": {


### PR DESCRIPTION
Fixes #51 : actually a **layers** property inside the backend config does not exist, what we have are some attributes organized the same way as we have it at the service level for the `layers` sections: a way to add static attributes and other params to the backend, but also to disable the stage.

This is config example that allows to **disable_stage** for the traces part of one single backend, and we add some attributes for the other part:

```json
{
  "@comment": "Feature: OTEL Backend detailed configurations",
  "endpoint": "/user/creditcard",
  "backend": [
    {
      "host": ["{{.fake_api}}"],
      "url_pattern": "/user/1.json",
      "allow": [
        "credit_card"
      ],
          "extra_config": {
              "telemetry/opentelemetry": {
                    "backend": {
                        "traces": {
                            "static_attributes": [
                                {
                                    "key": "b_innerlayer",
                                    "value": "b__innerlayer_value" 
                                }
                            ],
                            "disable_stage": true
                        }
                    }
                 }
          }
    },
    {
      "host": ["{{.fake_api}}"],
      "url_pattern": "/hotels/1.json",
      "allow": [
        "name"
      ],
          "extra_config": {
              "telemetry/opentelemetry": {
                    "backend": {
                        "traces": {
                            "static_attributes": [
                                {
                                    "key": "c_innerlayer",
                                    "value": "c__innerlayer_value" 
                                }
                            ],
                            "disable_stage": false
                        }
                    }
                 }
          }
    }
  ]

}
```

See the `extra_config` parts above, and the result for a trace here with the attributes:

![backend_attributes_set](https://github.com/user-attachments/assets/3442787d-ae5f-4da7-99ba-721a7f37c7cb)

And we can see that the call to `user/1.json` is not shown:

![screenshot_2024_10_09__16_35_05](https://github.com/user-attachments/assets/68853b4f-d7e3-4c3c-9ca1-add72696b3d8)


So, it **works as documented** in the [official documentation](https://www.krakend.io/docs/enterprise/telemetry/opentelemetry-by-endpoint/#backend-override-of-metrics-and-traces), but , in what is **missing from the documentation is the `static_attributes` property**, that allows to add more attributes. 

What is wrong in the [official documentation](https://www.krakend.io/docs/enterprise/telemetry/opentelemetry-by-endpoint/#backend-override-of-metrics-and-traces), is that backend's `extra_config` -> `telemetry/opentelemetry` accepts the `proxy` properties. We cannot disable that at this inner level. 

Also, in the **endpoint** section to override config, you can also have the `backend` section, that provides a custom config for the backends that this endpoints uses. So the `backend` part must be added to the documentation here: https://www.krakend.io/docs/enterprise/telemetry/opentelemetry-by-endpoint/#endpoint-override-of-metrics-and-traces 