### PR TITLE
Add missing WS attribute

### DIFF
--- a/test/v2.9/all.json
+++ b/test/v2.9/all.json
@@ -445,7 +445,8 @@
                                 "pong_wait": "60s",
                                 "ping_period": "54s",
                                 "max_retries": 0,
-                                "backoff_strategy": "exponential"
+                                "backoff_strategy": "exponential",
+                                "disable_otel_metrics": true
                             },
                             "modifier/response-body-generator": {
                                 "content_type": "application/json",

--- a/v2.8/backend/grpc.json
+++ b/v2.8/backend/grpc.json
@@ -70,7 +70,7 @@
     },
     "output_remove_unset_values": {
       "title": "Output removes unset values",
-      "description": "When the response has missing fields from the definition, they are returned with default values. Setting this flag to `true` removes those fields from the response, while setting it to `false` or not setting it, returns all the fields in the definition.\n\nSee: https://www.krakend.io/docs/enterprise/backends/grpc/",
+      "description": "This attribute defines what to do when a field that is declared in the definition does not exist in the backend response. When the flag is `true`, any fields in the definition that are not present in the backend response are removed before returning the content to the user. When the flag is `false` missing fields are returned but set with a zeroed-value depending on its type (zero, nil, false, etc).\n\nSee: https://www.krakend.io/docs/enterprise/backends/grpc/",
       "default": false,
       "type": "boolean"
     },

--- a/v2.8/websocket.json
+++ b/v2.8/websocket.json
@@ -23,6 +23,12 @@
       "default": false,
       "type": "boolean"
     },
+    "disable_otel_metrics": {
+      "title": "Disable OpenTelemetry metrics",
+      "description": "Disables the OpenTelemetry metrics for the websocket connections.\n\nSee: https://www.krakend.io/docs/enterprise/websockets/",
+      "default": false,
+      "type": "boolean"
+    },
     "disconnect_event": {
       "title": "Notify disconnections",
       "description": "Whether to send notification events to the backend or not when users disconnect from their Websockets connection.\n\nSee: https://www.krakend.io/docs/enterprise/websockets/",

--- a/v2.9/backend/grpc.json
+++ b/v2.9/backend/grpc.json
@@ -70,7 +70,7 @@
     },
     "output_remove_unset_values": {
       "title": "Output removes unset values",
-      "description": "When the response has missing fields from the definition, they are returned with default values. Setting this flag to `true` removes those fields from the response, while setting it to `false` or not setting it, returns all the fields in the definition.\n\nSee: https://www.krakend.io/docs/enterprise/backends/grpc/",
+      "description": "This attribute defines what to do when a field that is declared in the definition does not exist in the backend response. When the flag is `true`, any fields in the definition that are not present in the backend response are removed before returning the content to the user. When the flag is `false` missing fields are returned but set with a zeroed-value depending on its type (zero, nil, false, etc).\n\nSee: https://www.krakend.io/docs/enterprise/backends/grpc/",
       "default": false,
       "type": "boolean"
     },

--- a/v2.9/krakend.json
+++ b/v2.9/krakend.json
@@ -1902,7 +1902,7 @@
         },
         "output_remove_unset_values": {
           "title": "Output removes unset values",
-          "description": "When the response has missing fields from the definition, they are returned with default values. Setting this flag to `true` removes those fields from the response, while setting it to `false` or not setting it, returns all the fields in the definition.\n\nSee: https://www.krakend.io/docs/enterprise/backends/grpc/",
+          "description": "This attribute defines what to do when a field that is declared in the definition does not exist in the backend response. When the flag is `true`, any fields in the definition that are not present in the backend response are removed before returning the content to the user. When the flag is `false` missing fields are returned but set with a zeroed-value depending on its type (zero, nil, false, etc).\n\nSee: https://www.krakend.io/docs/enterprise/backends/grpc/",
           "default": false,
           "type": "boolean"
         },
@@ -9062,6 +9062,12 @@
         "connect_event": {
           "title": "Notify connections",
           "description": "Whether to send notification events to the backend or not when a user establishes a new Websockets connection.\n\nSee: https://www.krakend.io/docs/enterprise/websockets/",
+          "default": false,
+          "type": "boolean"
+        },
+        "disable_otel_metrics": {
+          "title": "Disable OpenTelemetry metrics",
+          "description": "Disables the OpenTelemetry metrics for the websocket connections.\n\nSee: https://www.krakend.io/docs/enterprise/websockets/",
           "default": false,
           "type": "boolean"
         },

--- a/v2.9/websocket.json
+++ b/v2.9/websocket.json
@@ -23,6 +23,12 @@
       "default": false,
       "type": "boolean"
     },
+    "disable_otel_metrics": {
+      "title": "Disable OpenTelemetry metrics",
+      "description": "Disables the OpenTelemetry metrics for the websocket connections.\n\nSee: https://www.krakend.io/docs/enterprise/websockets/",
+      "default": false,
+      "type": "boolean"
+    },
     "disconnect_event": {
       "title": "Notify disconnections",
       "description": "Whether to send notification events to the backend or not when users disconnect from their Websockets connection.\n\nSee: https://www.krakend.io/docs/enterprise/websockets/",


### PR DESCRIPTION
- Added `disable_otel_metrics` to the websockets component for v2.8 and v2.9 (future)
- Improved the description of the `output_remove_unset_values` for backend/grpc