### PR TITLE
Remove limitations on supported methods for http backends

### DIFF
--- a/test/v2.9/backend.json
+++ b/test/v2.9/backend.json
@@ -11,6 +11,14 @@
             "valid": false
         },
         {
+            "description": "Unusual methods",
+            "data": {
+                "method": "OPTIONS",
+                "url_pattern": "/__debug/root"
+            },
+            "valid": true
+        },
+        {
             "description": "Simple backend declaration with no host",
             "data": {
                 "url_pattern": "/__debug/root"

--- a/v2.1/backend.json
+++ b/v2.1/backend.json
@@ -89,14 +89,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.2/backend.json
+++ b/v2.2/backend.json
@@ -89,14 +89,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.3/backend.json
+++ b/v2.3/backend.json
@@ -89,14 +89,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.4/backend.json
+++ b/v2.4/backend.json
@@ -106,14 +106,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.5/backend.json
+++ b/v2.5/backend.json
@@ -123,14 +123,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.6/backend.json
+++ b/v2.6/backend.json
@@ -139,14 +139,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.7/backend.json
+++ b/v2.7/backend.json
@@ -143,14 +143,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.8/backend.json
+++ b/v2.8/backend.json
@@ -151,14 +151,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.8/krakend.json
+++ b/v2.8/krakend.json
@@ -1490,14 +1490,18 @@
         },
         "method": {
           "title": "Method",
-          "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+          "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
           "default": "GET",
           "enum": [
             "GET",
             "POST",
             "PUT",
             "PATCH",
-            "DELETE"
+            "DELETE",
+            "OPTIONS",
+            "HEAD",
+            "CONNECT",
+            "TRACE"
           ]
         },
         "sd": {

--- a/v2.9/backend.json
+++ b/v2.9/backend.json
@@ -151,14 +151,18 @@
     "method": {
       "$id": "#backend/method",
       "title": "Method",
-      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+      "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
       "default": "GET",
       "enum": [
         "GET",
         "POST",
         "PUT",
         "PATCH",
-        "DELETE"
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "CONNECT",
+        "TRACE"
       ]
     },
     "sd": {

--- a/v2.9/krakend.json
+++ b/v2.9/krakend.json
@@ -1490,14 +1490,18 @@
         },
         "method": {
           "title": "Method",
-          "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method.\n\nSee: https://www.krakend.io/docs/backends/",
+          "description": "The method sent to this backend in **uppercase**. The method does not need to match the endpoint's method. When the value is omitted, it uses the same endpoint's method. Some special methods will require you to use no-op encoding (like HEAD or OPTIONS) when these return an empty body.\n\nSee: https://www.krakend.io/docs/backends/",
           "default": "GET",
           "enum": [
             "GET",
             "POST",
             "PUT",
             "PATCH",
-            "DELETE"
+            "DELETE",
+            "OPTIONS",
+            "HEAD",
+            "CONNECT",
+            "TRACE"
           ]
         },
         "sd": {


### PR DESCRIPTION
Accept `OPTIONS`, `HEAD` and other special methods on the backend section