### PR TITLE
Make schema validation of modifier/response-body stricter

### DIFF
--- a/test/v2.9/modifier/response-body.json
+++ b/test/v2.9/modifier/response-body.json
@@ -47,6 +47,56 @@
         ]
       },
       "valid": true
+    },
+    {
+      "description": "incorrect array definition under regexp",
+      "valid": false,
+      "data": {
+        "modifiers": [
+          {
+            "regexp": [
+              {
+                "field": "credit_card.number",
+                "@comment": "Ridiculous card masking. Show last 4 digits and remove the rest. Credit card number is nested.",
+                "find": "^.*(\\d{4})",
+                "replace": "XXXX-${1}"
+              }
+            ]
+          },
+          {
+            "literal": [
+              {
+                "field": "surname",
+                "find": " supu",
+                "replace": "tupu"
+              }
+            ]
+          },
+          {
+            "upper": [
+              {
+                "@comment": "We want all surnames uppercased, like SMITH",
+                "field": "surname"
+              }
+            ]
+          },
+          {
+            "lower": [
+              {
+                "field": "dawsesad"
+              }
+            ]
+          },
+          {
+            "trim": [
+              {
+                "field": "trimmy",
+                "find": "A"
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/v2.9/krakend.json
+++ b/v2.9/krakend.json
@@ -4700,14 +4700,13 @@
                 "title": "Literal replacement",
                 "description": "A literal replacement of strings (case sensitive).\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
                 "examples": [
-                  [
-                    {
-                      "field": "data.example",
-                      "find": "findme",
-                      "replace": "replaceme"
-                    }
-                  ]
+                  {
+                    "field": "data.example",
+                    "find": "findme",
+                    "replace": "replaceme"
+                  }
                 ],
+                "type": "object",
                 "required": [
                   "field",
                   "find",
@@ -4742,12 +4741,11 @@
                 "title": "Lowercase",
                 "description": "Converts a given string to lowercase.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
                 "examples": [
-                  [
-                    {
-                      "field": "surname"
-                    }
-                  ]
+                  {
+                    "field": "surname"
+                  }
                 ],
+                "type": "object",
                 "required": [
                   "field"
                 ],
@@ -4770,14 +4768,13 @@
                 "title": "Regular expression modifier",
                 "description": "A list of regular expressions you would like to apply to specific fields. The expressions are evaluated and applied in sequential order.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
                 "examples": [
-                  [
-                    {
-                      "field": "data.credit_card",
-                      "find": "(^\\d{4})(.*)",
-                      "replace": "${1}-XXXX"
-                    }
-                  ]
+                  {
+                    "field": "data.credit_card",
+                    "find": "(^\\d{4})(.*)",
+                    "replace": "${1}-XXXX"
+                  }
                 ],
+                "type": "object",
                 "required": [
                   "field",
                   "find",
@@ -4815,13 +4812,12 @@
                 "title": "Trims by character",
                 "description": "Removes a specific set of characters from the beginning and the end of the string.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
                 "examples": [
-                  [
-                    {
-                      "field": "description",
-                      "find": "\n"
-                    }
-                  ]
+                  {
+                    "field": "description",
+                    "find": "\n"
+                  }
                 ],
+                "type": "object",
                 "required": [
                   "field",
                   "find"
@@ -4856,12 +4852,11 @@
                 "title": "Uppercase",
                 "description": "Converts a given string to uppercase.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
                 "examples": [
-                  [
-                    {
-                      "field": "surname"
-                    }
-                  ]
+                  {
+                    "field": "surname"
+                  }
                 ],
+                "type": "object",
                 "required": [
                   "field"
                 ],

--- a/v2.9/modifier/response-body.json
+++ b/v2.9/modifier/response-body.json
@@ -18,14 +18,13 @@
             "title": "Literal replacement",
             "description": "A literal replacement of strings (case sensitive).\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
             "examples": [
-              [
-                {
-                  "field": "data.example",
-                  "find": "findme",
-                  "replace": "replaceme"
-                }
-              ]
+              {
+                "field": "data.example",
+                "find": "findme",
+                "replace": "replaceme"
+              }
             ],
+            "type": "object",
             "required": [
               "field",
               "find",
@@ -60,12 +59,11 @@
             "title": "Lowercase",
             "description": "Converts a given string to lowercase.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
             "examples": [
-              [
-                {
-                  "field": "surname"
-                }
-              ]
+              {
+                "field": "surname"
+              }
             ],
+            "type": "object",
             "required": [
               "field"
             ],
@@ -88,14 +86,13 @@
             "title": "Regular expression modifier",
             "description": "A list of regular expressions you would like to apply to specific fields. The expressions are evaluated and applied in sequential order.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
             "examples": [
-              [
-                {
-                  "field": "data.credit_card",
-                  "find": "(^\\d{4})(.*)",
-                  "replace": "${1}-XXXX"
-                }
-              ]
+              {
+                "field": "data.credit_card",
+                "find": "(^\\d{4})(.*)",
+                "replace": "${1}-XXXX"
+              }
             ],
+            "type": "object",
             "required": [
               "field",
               "find",
@@ -133,13 +130,12 @@
             "title": "Trims by character",
             "description": "Removes a specific set of characters from the beginning and the end of the string.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
             "examples": [
-              [
-                {
-                  "field": "description",
-                  "find": "\n"
-                }
-              ]
+              {
+                "field": "description",
+                "find": "\n"
+              }
             ],
+            "type": "object",
             "required": [
               "field",
               "find"
@@ -174,12 +170,11 @@
             "title": "Uppercase",
             "description": "Converts a given string to uppercase.\n\nSee: https://www.krakend.io/docs/enterprise/endpoints/content-replacer/",
             "examples": [
-              [
-                {
-                  "field": "surname"
-                }
-              ]
+              {
+                "field": "surname"
+              }
             ],
+            "type": "object",
             "required": [
               "field"
             ],


### PR DESCRIPTION
Currently, the different modifiers of `modifier/response-body` do not enforce a type, so you can create an invalid modifier using an array instead of an object:


```
{
            "literal": [
              {
                "field": "surname",
                "find": " supu",
                "replace": "tupu"
              }
            ]
          },
```
vs the correct one:
```
{
            "literal": 
              {
                "field": "surname",
                "find": " supu",
                "replace": "tupu"
              }
          },
```