### PR TITLE
fix: otel global layer cannot be tweaked per endpoint

### DIFF
--- a/v2.13/krakend.json
+++ b/v2.13/krakend.json
@@ -6799,56 +6799,6 @@
           },
           "additionalProperties": false
         },
-        "global": {
-          "title": "Replace global configuration",
-          "description": "Overrides the global configuration for this endpoint.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-          "properties": {
-            "metrics_static_attributes": {
-              "title": "Static attributes",
-              "description": "Static attributes you want to pass for metrics. Overrides the `metrics_static_attributes` defined at the service level.",
-              "type": "array",
-              "items": {
-                "properties": {
-                  "key": {
-                    "title": "Key",
-                    "description": "The key of the static attribute you want to send",
-                    "type": "string"
-                  },
-                  "value": {
-                    "title": "Value",
-                    "description": "The value of the static attribute you want to send",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "traces_static_attributes": {
-              "title": "Static attributes",
-              "description": "Static attributes you want to pass for traces.  Overrides the `traces_static_attributes` defined at the service level.",
-              "type": "array",
-              "items": {
-                "properties": {
-                  "key": {
-                    "title": "Key",
-                    "description": "The key of the static attribute you want to send",
-                    "type": "string"
-                  },
-                  "value": {
-                    "title": "Value",
-                    "description": "The value of the static attribute you want to send",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            }
-          },
-          "patternProperties": {
-            "^[@$_#]": true
-          },
-          "additionalProperties": false
-        },
         "proxy": {
           "title": "Report proxy activity",
           "description": "Reports the activity at the beginning of the proxy layer, including spawning the required requests to multiple backends, merging, endpoint transformation and any other internals of the proxy between the request processing and the backend communication\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",

--- a/v2.13/telemetry/opentelemetry-endpoint.json
+++ b/v2.13/telemetry/opentelemetry-endpoint.json
@@ -211,56 +211,6 @@
       },
       "additionalProperties": false
     },
-    "global": {
-      "title": "Replace global configuration",
-      "description": "Overrides the global configuration for this endpoint.\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",
-      "properties": {
-        "metrics_static_attributes": {
-          "title": "Static attributes",
-          "description": "Static attributes you want to pass for metrics. Overrides the `metrics_static_attributes` defined at the service level.",
-          "type": "array",
-          "items": {
-            "properties": {
-              "key": {
-                "title": "Key",
-                "description": "The key of the static attribute you want to send",
-                "type": "string"
-              },
-              "value": {
-                "title": "Value",
-                "description": "The value of the static attribute you want to send",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "traces_static_attributes": {
-          "title": "Static attributes",
-          "description": "Static attributes you want to pass for traces.  Overrides the `traces_static_attributes` defined at the service level.",
-          "type": "array",
-          "items": {
-            "properties": {
-              "key": {
-                "title": "Key",
-                "description": "The key of the static attribute you want to send",
-                "type": "string"
-              },
-              "value": {
-                "title": "Value",
-                "description": "The value of the static attribute you want to send",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        }
-      },
-      "patternProperties": {
-        "^[@$_#]": true
-      },
-      "additionalProperties": false
-    },
     "proxy": {
       "title": "Report proxy activity",
       "description": "Reports the activity at the beginning of the proxy layer, including spawning the required requests to multiple backends, merging, endpoint transformation and any other internals of the proxy between the request processing and the backend communication\n\nSee: https://www.krakend.io/docs/telemetry/opentelemetry-by-endpoint/",


### PR DESCRIPTION
OpenTelemetry global layer cannot be tweaked per endpoint, because the trace is started before matching the route. 