### PR TITLE
fix: missing variables property for response body generator

### DIFF
--- a/v2.13/krakend.json
+++ b/v2.13/krakend.json
@@ -2168,6 +2168,11 @@
           "title": "Template",
           "description": "An inline base64 encoded Go template with the body you want to generate. This option is useful if you want to have the template embedded in the configuration instead of an external file.\n\nSee: https://www.krakend.io/docs/enterprise/backends/body-generator/",
           "type": "string"
+        },
+        "variables": {
+          "title": "Variables",
+          "description": "An object traversable with dots with any content you want to be available to the template.\n\nSee: https://www.krakend.io/docs/enterprise/backends/body-generator/",
+          "type": "object"
         }
       },
       "patternProperties": {

--- a/v2.13/modifier/body-generator.json
+++ b/v2.13/modifier/body-generator.json
@@ -37,6 +37,11 @@
       "title": "Template",
       "description": "An inline base64 encoded Go template with the body you want to generate. This option is useful if you want to have the template embedded in the configuration instead of an external file.\n\nSee: https://www.krakend.io/docs/enterprise/backends/body-generator/",
       "type": "string"
+    },
+    "variables": {
+      "title": "Variables",
+      "description": "An object traversable with dots with any content you want to be available to the template.\n\nSee: https://www.krakend.io/docs/enterprise/backends/body-generator/",
+      "type": "object"
     }
   },
   "patternProperties": {


### PR DESCRIPTION
Missing `"variables"` property for `response-body-generator` component. 