### PR TITLE
Add MCP server tool annotation support

### DIFF
--- a/test/v2.13/ai/mcp.json
+++ b/test/v2.13/ai/mcp.json
@@ -196,6 +196,133 @@
         ]
       },
       "valid": true
+    },
+    {
+      "description": "Tool with all the annotations hints set",
+      "data": {
+        "servers": [
+          {
+            "name": "story-tracker-tools",
+            "title": "Story tracker tools",
+            "version": "0.2.1",
+            "tools": [
+              {
+                "name": "story-list",
+                "title": "Story list",
+                "description": "Get a list of open stories in tracker matching a search query",
+                "annotations": {
+                  "open_world_hint": false,
+                  "idempotent_hint": false,
+                  "destructive_hint": false,
+                  "read_only_hint": false
+                },
+                "workflow": {
+                  "endpoint": "/__mcp/story-list",
+                  "backend": [
+                    {
+                      "url_pattern": "/api/v3/search/stories"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "description": "Tool with a partial annotations object",
+      "data": {
+        "servers": [
+          {
+            "name": "story-tracker-tools",
+            "title": "Story tracker tools",
+            "version": "0.2.1",
+            "tools": [
+              {
+                "name": "story-list",
+                "title": "Story list",
+                "description": "Get a list of open stories in tracker matching a search query",
+                "annotations": {
+                  "read_only_hint": true
+                },
+                "workflow": {
+                  "endpoint": "/__mcp/story-list",
+                  "backend": [
+                    {
+                      "url_pattern": "/api/v3/search/stories"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "description": "Tool with an unknown annotations hint",
+      "data": {
+        "servers": [
+          {
+            "name": "story-tracker-tools",
+            "title": "Story tracker tools",
+            "version": "0.2.1",
+            "tools": [
+              {
+                "name": "story-list",
+                "title": "Story list",
+                "description": "Get a list of open stories in tracker matching a search query",
+                "annotations": {
+                  "readonly_hint": true
+                },
+                "workflow": {
+                  "endpoint": "/__mcp/story-list",
+                  "backend": [
+                    {
+                      "url_pattern": "/api/v3/search/stories"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
+      "description": "Tool with a non-boolean annotations hint",
+      "data": {
+        "servers": [
+          {
+            "name": "story-tracker-tools",
+            "title": "Story tracker tools",
+            "version": "0.2.1",
+            "tools": [
+              {
+                "name": "story-list",
+                "title": "Story list",
+                "description": "Get a list of open stories in tracker matching a search query",
+                "annotations": {
+                  "read_only_hint": "true"
+                },
+                "workflow": {
+                  "endpoint": "/__mcp/story-list",
+                  "backend": [
+                    {
+                      "url_pattern": "/api/v3/search/stories"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/v2.13/ai/mcp.json
+++ b/v2.13/ai/mcp.json
@@ -77,6 +77,41 @@
                   "default": "text",
                   "enum": [ "text", "audio", "image" ]
                 },
+                "annotations": {
+                  "title": "Tool Annotations",
+                  "description": "Optional behavioral hints about this tool, so AI clients can decide how to use it. These are hints only and are not guaranteed to be enforced.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                  "type": "object",
+                  "properties": {
+                    "destructive_hint": {
+                      "title": "Destructive Hint",
+                      "description": "Set to true if the tool may perform destructive updates, meaning it can delete or overwrite existing data. Only meaningful when `read_only_hint` is false.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "idempotent_hint": {
+                      "title": "Idempotent Hint",
+                      "description": "Set to true if calling the tool repeatedly with the same arguments has no additional effect beyond the first call. Only meaningful when `read_only_hint` is false.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "open_world_hint": {
+                      "title": "Open World Hint",
+                      "description": "Set to true if the tool interacts with an open, external world (for instance a public API or a web search) instead of a closed, well-known set of entities.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "read_only_hint": {
+                      "title": "Read Only Hint",
+                      "description": "Set to true if the tool does not modify its environment and only reads data.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                      "default": false,
+                      "type": "boolean"
+                    }
+                  },
+                  "patternProperties": {
+                    "^[@$_#]": true
+                  },
+                  "additionalProperties": false
+                },
                 "input_headers": {
                   "title": "Allowed Headers In",
                   "description": "Defines the list of all headers allowed to reach the backend when passed.\nBy default, KrakenD won't pass any header from the client to the backend. This list is **case-insensitive**. You can declare headers in lowercase, uppercase, or mixed.\nAn entry `[\"Cookie\"]` forwards all cookies, and a single star element `[\"*\"]` as value forwards everything to the backend (**it's safer to avoid this option**), including cookies. See [headers forwarding](https://www.krakend.io/docs/endpoints/parameter-forwarding/#headers-forwarding)",

--- a/v2.13/krakend.json
+++ b/v2.13/krakend.json
@@ -7538,6 +7538,41 @@
                       "default": "text",
                       "enum": [ "text", "audio", "image" ]
                     },
+                    "annotations": {
+                      "title": "Tool Annotations",
+                      "description": "Optional behavioral hints about this tool, so AI clients can decide how to use it. These are hints only and are not guaranteed to be enforced.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                      "type": "object",
+                      "properties": {
+                        "destructive_hint": {
+                          "title": "Destructive Hint",
+                          "description": "Set to true if the tool may perform destructive updates, meaning it can delete or overwrite existing data. Only meaningful when `read_only_hint` is false.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "idempotent_hint": {
+                          "title": "Idempotent Hint",
+                          "description": "Set to true if calling the tool repeatedly with the same arguments has no additional effect beyond the first call. Only meaningful when `read_only_hint` is false.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "open_world_hint": {
+                          "title": "Open World Hint",
+                          "description": "Set to true if the tool interacts with an open, external world (for instance a public API or a web search) instead of a closed, well-known set of entities.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "read_only_hint": {
+                          "title": "Read Only Hint",
+                          "description": "Set to true if the tool does not modify its environment and only reads data.\n\nSee: https://www.krakend.io/docs/enterprise/ai-gateway/mcp-server/",
+                          "default": false,
+                          "type": "boolean"
+                        }
+                      },
+                      "patternProperties": {
+                        "^[@$_#]": true
+                      },
+                      "additionalProperties": false
+                    },
                     "input_headers": {
                       "title": "Allowed Headers In",
                       "description": "Defines the list of all headers allowed to reach the backend when passed.\nBy default, KrakenD won't pass any header from the client to the backend. This list is **case-insensitive**. You can declare headers in lowercase, uppercase, or mixed.\nAn entry `[\"Cookie\"]` forwards all cookies, and a single star element `[\"*\"]` as value forwards everything to the backend (**it's safer to avoid this option**), including cookies. See [headers forwarding](https://www.krakend.io/docs/endpoints/parameter-forwarding/#headers-forwarding)",


### PR DESCRIPTION
### Changes
* Added a new `annotations` optional object to MCP Server tools
* Added 5 optional annotations: `title`, `read_only_hint`, `destructive_hint`, `open_world_hint` and `idempotent_hint`
* Covered by simple test cases